### PR TITLE
Make the WebserverService protocol and service be implemented via metadata-based protocol extension

### DIFF
--- a/examples/ring_app/src/examples/ring_app/example_services.clj
+++ b/examples/ring_app/src/examples/ring_app/example_services.clj
@@ -19,6 +19,7 @@
     (new-hit-counts endpoint)))
 
 (defprotocol CountService
+  :extend-via-metadata true
   (inc-and-get [this endpoint]))
 
 (defservice count-service

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (def jetty-version "9.4.28.v20200408")
 
-(defproject puppetlabs/trapperkeeper-webserver-jetty9 "4.1.1-SNAPSHOT"
+(defproject threatgrid/trapperkeeper-webserver-jetty9 "4.2.0"
   :description "A jetty9-based webserver implementation for use with the puppetlabs/trapperkeeper service framework."
   :url "https://github.com/puppetlabs/trapperkeeper-webserver-jetty9"
   :license {:name "Apache License, Version 2.0"

--- a/src/puppetlabs/experimental/websockets/client.clj
+++ b/src/puppetlabs/experimental/websockets/client.clj
@@ -2,6 +2,7 @@
 
 (defprotocol WebSocketProtocol
   "Functions to manage the lifecycle of a websocket session"
+  :extend-via-metadata true
   (idle-timeout! [this ms]
     "Set the idle timeout for the session, in milliseconds")
   (connected? [this]

--- a/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service.clj
@@ -8,6 +8,7 @@
     [schema.core :as schema]))
 
 (defprotocol WebroutingService
+  :extend-via-metadata true
   (get-route [this svc] [this svc route-id])
   (get-server [this svc] [this svc route-id])
   (add-context-handler [this svc context-path] [this svc context-path options])

--- a/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_core.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.trapperkeeper.services.webrouting.webrouting-service-core
   (:require [schema.core :as schema]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-core :as jetty9-core]
+            [puppetlabs.trapperkeeper.services.webserver.jetty9-service.utils :refer [protocol]]
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.i18n.core :as i18n]))
 
@@ -103,7 +104,7 @@
 
 (schema/defn ^:always-validate get-server :- (schema/maybe schema/Str)
   [context
-   svc :- (schema/protocol tk-services/Service)
+   svc :- (protocol tk-services/Service)
    route-id]
   (let [svc-id              (keyword (tk-services/service-symbol svc))
         endpoint-and-server (get-endpoint-and-server-from-config context
@@ -113,7 +114,7 @@
 
 (schema/defn ^:always-validate add-context-handler!
   [context webserver-service
-   svc :- (schema/protocol tk-services/Service)
+   svc :- (protocol tk-services/Service)
    base-path
    options :- ContextHandlerOptions]
   (let [{:keys [path opts]} (compute-common-elements context svc options)
@@ -122,7 +123,7 @@
 
 (schema/defn ^:always-validate add-ring-handler!
   [context webserver-service
-   svc :- (schema/protocol tk-services/Service)
+   svc :- (protocol tk-services/Service)
    handler options :- CommonOptions]
   (let [{:keys [path opts]} (compute-common-elements context svc options)
         add-ring-handler    (:add-ring-handler webserver-service)]
@@ -130,7 +131,7 @@
 
 (schema/defn ^:always-validate add-servlet-handler!
   [context webserver-service
-   svc :- (schema/protocol tk-services/Service)
+   svc :- (protocol tk-services/Service)
    servlet options :- ServletHandlerOptions]
   (let [{:keys [path opts]} (compute-common-elements context svc options)
         add-servlet-handler (:add-servlet-handler webserver-service)]
@@ -138,7 +139,7 @@
 
 (schema/defn ^:always-validate add-websocket-handler!
   [context webserver-service
-   svc :- (schema/protocol tk-services/Service)
+   svc :- (protocol tk-services/Service)
    handlers options :- CommonOptions]
   (let [{:keys [path opts]}   (compute-common-elements context svc options)
         add-websocket-handler (:add-websocket-handler webserver-service)]
@@ -146,7 +147,7 @@
 
 (schema/defn ^:always-validate add-war-handler!
   [context webserver-service
-   svc :- (schema/protocol tk-services/Service)
+   svc :- (protocol tk-services/Service)
    war options :- RouteOption]
   (let [{:keys [path opts]} (compute-common-elements context svc options)
         add-war-handler     (:add-war-handler webserver-service)]
@@ -154,7 +155,7 @@
 
 (schema/defn ^:always-validate add-proxy-route!
   [context webserver-service
-   svc :- (schema/protocol tk-services/Service)
+   svc :- (protocol tk-services/Service)
    target options :- ProxyRouteOptions]
   (let [{:keys [path opts]} (compute-common-elements context svc options)
         add-proxy-route     (:add-proxy-route webserver-service)]

--- a/src/puppetlabs/trapperkeeper/services/webserver/experimental/jetty9_websockets.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/experimental/jetty9_websockets.clj
@@ -20,6 +20,7 @@
    (schema/optional-key :on-bytes) IFn})
 
 (defprotocol WebSocketSend
+  :extend-via-metadata true
   (-send! [x ws] "How to encode content sent to the WebSocket clients"))
 
 (extend-protocol WebSocketSend

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_core.clj
@@ -31,6 +31,7 @@
             [ring.util.codec :as codec]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [puppetlabs.trapperkeeper.services.webserver.jetty9-service.utils :refer [protocol]]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-config :as config]
             [puppetlabs.trapperkeeper.services.webserver.experimental.jetty9-websockets :as websockets]
             [puppetlabs.trapperkeeper.services.webserver.normalized-uri-helpers
@@ -993,7 +994,7 @@
   "Reload the CRL file used by the supplied ssl-context-factory whenever any
   changes to the file occur."
   [ssl-context-factory :- InternalSslContextFactory
-   watcher :- (schema/protocol watch-protocol/Watcher)]
+   watcher :- (protocol watch-protocol/Watcher)]
   (when-let [crl-path (.getCrlPath ssl-context-factory)]
     (let [normalized-crl-path (.getCanonicalPath (fs/file crl-path))]
       (watch-protocol/add-watch-dir! watcher (fs/parent crl-path))

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service.clj
@@ -17,6 +17,7 @@
 ;; TODO: this should probably be moved to a separate jar that can be used as
 ;; a dependency for all webserver service implementations
 (defprotocol WebserverService
+  :extend-via-metadata true
   (add-context-handler [this base-path context-path] [this base-path context-path options])
   (add-ring-handler [this handler path] [this handler path options])
   (add-websocket-handler [this handlers path] [this handler path options])

--- a/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service/utils.clj
+++ b/src/puppetlabs/trapperkeeper/services/webserver/jetty9_service/utils.clj
@@ -1,0 +1,20 @@
+(ns puppetlabs.trapperkeeper.services.webserver.jetty9-service.utils
+  (:refer-clojure :exclude [satisfies?])
+  (:require
+   [schema.core :as schema])
+  (:import (clojure.lang IMeta)))
+
+(defn satisfies? [{:keys [extend-via-metadata method-builders] :as protocol}
+                  val]
+  (or (and extend-via-metadata
+           (instance? IMeta val)
+           (some (partial contains? (meta val))
+                 (map symbol (keys method-builders))))
+      (clojure.core/satisfies? protocol val)))
+
+(defmacro protocol [p]
+  (let [pn (-> p str symbol)]
+    `(schema/pred (fn ~(symbol (str (some-> pn namespace str (str "--"))
+                                    (-> pn name str)))
+                    [~'x]
+                    (satisfies? ~p ~'x)))))

--- a/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_handlers_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_handlers_test.clj
@@ -19,6 +19,7 @@
 (def dev-resources-dir        "./dev-resources/")
 
 (defprotocol TestDummy
+  :extend-via-metadata true
   (dummy [this]))
 
 (tk-services/defservice test-dummy
@@ -211,5 +212,3 @@
           (log-registered-endpoints)
           (is (logged? #"^\{\"\/foo\" \[\{:type :ring}\]\}$"))
           (is (logged? #"^\{\"\/foo\" \[\{:type :ring}\]\}$" :info)))))))
-
-

--- a/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_override_settings_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_override_settings_test.clj
@@ -20,6 +20,7 @@
 (def dev-resources-config-dir (str dev-resources-dir "config/jetty/"))
 
 (defprotocol TestDummy
+  :extend-via-metadata true
   (dummy [this]))
 
 (tk-services/defservice test-dummy

--- a/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_proxy_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_proxy_test.clj
@@ -14,9 +14,11 @@
   testutils/assert-clean-shutdown)
 
 (defprotocol DummyService1
+  :extend-via-metadata true
   (dummy1 [this]))
 
 (defprotocol DummyService2
+  :extend-via-metadata true
   (dummy2 [this]))
 
 (tk-services/defservice dummy-service1

--- a/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webrouting/webrouting_service_test.clj
@@ -27,13 +27,17 @@
   testutils/assert-clean-shutdown)
 
 (defprotocol TestService
+  :extend-via-metadata true
   (hello [this]))
 
-(defprotocol TestService2)
+(defprotocol TestService2
+  :extend-via-metadata true)
 
-(defprotocol TestService3)
+(defprotocol TestService3
+  :extend-via-metadata true)
 
 (defprotocol NotReal
+  :extend-via-metadata true
   (dummy [this]))
 
 (tk-services/defservice test-service

--- a/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_proxy_test.clj
+++ b/test/clj/puppetlabs/trapperkeeper/services/webserver/jetty9_service_proxy_test.clj
@@ -75,7 +75,8 @@
     {:status 200
      :body   "This should have timed out."}))
 
-(defprotocol TkProxyService)
+(defprotocol TkProxyService
+  :extend-via-metadata true)
 
 (defn proxy-service
   [proxy-config proxy-opts proxy-path]


### PR DESCRIPTION
Released as `[threatgrid/trapperkeeper-webserver-jetty9 "4.2.0"]`